### PR TITLE
Add commemoration tests and iCal generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode/
+.vscode/

--- a/common.test.mjs
+++ b/common.test.mjs
@@ -1,7 +1,74 @@
-import { getGreeting } from "./common.mjs";
+import { calculateCommemorationDate, getMonthNumber, getWeekdayNumber } from "./common.mjs";
 import assert from "node:assert";
 import test from "node:test";
 
-test("Greeting is correct", () => {
-  assert.equal(getGreeting(), "Hello");
+test("getMonthNumber returns correct index for January", () => {
+  assert.equal(getMonthNumber("January"), 0);
+});
+
+test("getMonthNumber returns correct index for December", () => {
+  assert.equal(getMonthNumber("December"), 11);
+});
+
+test("getWeekdayNumber returns correct index for Sunday", () => {
+  assert.equal(getWeekdayNumber("Sunday"), 0);
+});
+
+test("getWeekdayNumber returns correct index for Saturday", () => {
+  assert.equal(getWeekdayNumber("Saturday"), 6);
+});
+
+test("Ada Lovelace Day 2024 - second Tuesday of October", () => {
+  const result = calculateCommemorationDate(2024, "October", "Tuesday", "second");
+  assert.equal(result, 8);
+});
+
+test("Ada Lovelace Day 2025 - second Tuesday of October", () => {
+  const result = calculateCommemorationDate(2025, "October", "Tuesday", "second");
+  assert.equal(result, 14);
+});
+
+test("Ada Lovelace Day 2020 - second Tuesday of October", () => {
+  const result = calculateCommemorationDate(2020, "October", "Tuesday", "second");
+  assert.equal(result, 13);
+});
+
+test("World Lemur Day 2024 - last Friday of October", () => {
+  const result = calculateCommemorationDate(2024, "October", "Friday", "last");
+  assert.equal(result, 25);
+});
+
+test("World Lemur Day 2020 - last Friday of October", () => {
+  const result = calculateCommemorationDate(2020, "October", "Friday", "last");
+  assert.equal(result, 30);
+});
+
+test("International Vulture Awareness Day 2024 - first Saturday of September", () => {
+  const result = calculateCommemorationDate(2024, "September", "Saturday", "first");
+  assert.equal(result, 7);
+});
+
+test("International Red Panda Day 2024 - third Saturday of September", () => {
+  const result = calculateCommemorationDate(2024, "September", "Saturday", "third");
+  assert.equal(result, 21);
+});
+
+test("Fourth Monday of January 2024", () => {
+  const result = calculateCommemorationDate(2024, "January", "Monday", "fourth");
+  assert.equal(result, 22);
+});
+
+test("International Binturong Day 2030 - second Saturday of May", () => {
+  const result = calculateCommemorationDate(2030, "May", "Saturday", "second");
+  assert.equal(result, 11);
+});
+
+test("First Sunday when month starts on Sunday", () => {
+  const result = calculateCommemorationDate(2024, "September", "Sunday", "first");
+  assert.equal(result, 1);
+});
+
+test("Last Saturday in February 2025", () => {
+  const result = calculateCommemorationDate(2025, "February", "Saturday", "last");
+  assert.equal(result, 22);
 });

--- a/generate-ical.mjs
+++ b/generate-ical.mjs
@@ -1,7 +1,65 @@
 // This is a placeholder file which shows how you can access functions and data defined in other files. You can delete the contents of the file once you have understood how it works.
 // It can be run with `node`.
 
-import { getGreeting } from "./common.mjs";
-import daysData from "./days.json" with { type: "json" };
+// generate-ical.mjs
+// Run with: node generate-ical.mjs
+// Generates days.ics for years 2020–2030 (inclusive)
 
-console.log(`{getGreeting()} - there are ${daysData.length} known days`);
+import fs from "fs";
+import daysData from "./days.json" with { type: "json" };
+import { calculateCommemorationDate, getMonthNumber } from "./common.mjs";
+
+const START_YEAR = 2020;
+const END_YEAR = 2030;
+
+function formatDate(year, month, day) {
+  const mm = String(month + 1).padStart(2, "0");
+  const dd = String(day).padStart(2, "0");
+  return `${year}${mm}${dd}`;
+}
+
+function getCurrentTimestamp() {
+  const now = new Date();
+  return now.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
+}
+
+let ics = "";
+ics += "BEGIN:VCALENDAR\n";
+ics += "VERSION:2.0\n";
+ics += "PRODID:-//Days Calendar//EN\n";
+
+const timestamp = getCurrentTimestamp();
+
+for (let year = START_YEAR; year <= END_YEAR; year++) {
+  for (const day of daysData) {
+    const month = getMonthNumber(day.monthName);
+    const date = calculateCommemorationDate(
+      year,
+      day.monthName,
+      day.dayName,
+      day.occurrence
+    );
+
+    const formattedDate = formatDate(year, month, date);
+    
+    const nextDay = new Date(year, month, date + 1, 12);
+    const endDate = formatDate(
+      nextDay.getFullYear(),
+      nextDay.getMonth(),
+      nextDay.getDate()
+    );
+
+    ics += "BEGIN:VEVENT\n";
+    ics += `UID:${day.name.replace(/\s+/g, "-")}-${year}@days-calendar\n`;
+    ics += `DTSTAMP:${timestamp}\n`;
+    ics += `DTSTART;VALUE=DATE:${formattedDate}\n`;
+    ics += `DTEND;VALUE=DATE:${endDate}\n`;
+    ics += `SUMMARY:${day.name}\n`;
+    ics += "END:VEVENT\n";
+  }
+}
+
+ics += "END:VCALENDAR\n";
+
+fs.writeFileSync("days.ics", ics);
+console.log("Generated days.ics");

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "project-days-calendar",
   "version": "1.0.0",
+  "type": "module",
   "scripts": {
-    "test": "node common.test.mjs"
+    "test": "node common.test.mjs",
+    "generate-ical": "node generate-ical.mjs"
   }
 }


### PR DESCRIPTION
This PR adds the following enhancements:

   **Commemoration Test Suite**  
    - Complete tests for `calculateCommemorationDate`, `getMonthNumber`, and `getWeekdayNumber`.  
    - Covers first, second, third, fourth, and last occurrences.  
    - Edge cases included (month starting/ending on target weekday).  

   **iCal Generator (`generate-ical.mjs`)**  
    - Generates `days.ics` for years 2020–2030.  
    - Uses `days.json` data and calculation functions.  
    - Supports all-day events in proper iCal format.  

 All tests pass and script runs successfully.  
